### PR TITLE
Add en_depent_web_md compatibility

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -4,12 +4,14 @@
             "en_core_web_md": ["1.2.0"],
             "en_core_web_sm": ["1.2.0"],
             "de_core_news_md": ["1.0.0"],
+            "en_depent_web_md": ["1.2.0"],
             "en_vectors_glove_md": ["1.0.0"]
         },
         "1.7.0": {
             "en_core_web_md": ["1.2.0"],
             "en_core_web_sm": ["1.2.0"],
             "de_core_news_md": ["1.0.0"],
+            "en_depent_web_md": ["1.2.0"],
             "en_vectors_glove_md": ["1.0.0"]
         },
         "1.6.0": {


### PR DESCRIPTION
Also @ines: in the `en_depent_web_md` you wrote `en_core_depent_md` instead of `en_depent_web_md` as the "modelname".