### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ pip install /Users/you/en_core_web_sm-2.0.0.tar.gz
 pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz
 
 # set up shortcut link to load installed package as "en_default"
-python -m spacy link en_core_web_s en_default
+python -m spacy link en_core_web_sm en_default
 
 # set up shortcut link to load local model as "my_amazing_model"
 python -m spacy link /Users/you/data my_amazing_model


### PR DESCRIPTION
Corrected typo error in model name for linkage command.

Because of this it was throwing error in linkage:
spacy>python -m spacy link en_core_web_s en_default

    Can't locate model data
    The data should be located in en_core_web_s