### PR TITLE
Modify en tagger test to check verb lemmas

### DIFF
--- a/tests/lang/en/test_tagger.py
+++ b/tests/lang/en/test_tagger.py
@@ -87,12 +87,13 @@ def test_en_tagger_lemma_nouns(lemmatizer, text, lemmas, morphology):
     assert sorted(lemmatizer.noun(text, morphology=morphology)) == lemmas
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "text,lemmas",
     [("bleed", ["bleed"]), ("feed", ["feed"]), ("need", ["need"]), ("ring", ["ring"])],
 )
 def test_en_tagger_lemma_verbs(lemmatizer, text, lemmas):
-    assert lemmatizer.noun(text) == lemmas
+    assert lemmatizer.verb(text) == lemmas
 
 
 def test_en_tagger_lemma_base_forms(lemmatizer):


### PR DESCRIPTION
`test_en_tagger_lemma_verbs()` was checking noun rather than verb lemmatization. The test no longer passes because the default `lemmatizer.verb()` lemmatizes most of these forms (`bleed`, `need`, `ring`) incorrectly.