### PR TITLE
Add ja_core_web_md-2.1.0

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -16,6 +16,7 @@
             "el_core_news_md": ["2.1.0"],
             "it_core_news_sm": ["2.1.0"],
             "nl_core_news_sm": ["2.1.0"],
+            "ja_core_web_md": ["2.1.0"],
             "xx_ent_wiki_sm": ["2.1.0"]
         },
         "2.1.3": {
@@ -34,6 +35,7 @@
             "el_core_news_md": ["2.1.0"],
             "it_core_news_sm": ["2.1.0"],
             "nl_core_news_sm": ["2.1.0"],
+            "ja_core_web_md": ["2.1.0"],
             "xx_ent_wiki_sm": ["2.1.0"]
         },
         "2.1.2": {
@@ -52,6 +54,7 @@
             "el_core_news_md": ["2.1.0"],
             "it_core_news_sm": ["2.1.0"],
             "nl_core_news_sm": ["2.1.0"],
+            "ja_core_web_md": ["2.1.0"],
             "xx_ent_wiki_sm": ["2.1.0"]
         },
         "2.1.1": {
@@ -70,6 +73,7 @@
             "el_core_news_md": ["2.1.0"],
             "it_core_news_sm": ["2.1.0"],
             "nl_core_news_sm": ["2.1.0"],
+            "ja_core_web_md": ["2.1.0"],
             "xx_ent_wiki_sm": ["2.1.0"]
         },
         "2.1.0": {
@@ -88,6 +92,7 @@
             "el_core_news_md": ["2.1.0"],
             "it_core_news_sm": ["2.1.0"],
             "nl_core_news_sm": ["2.1.0"],
+            "ja_core_web_md": ["2.1.0"],
             "xx_ent_wiki_sm": ["2.1.0"]
         },
         "2.0.18": {

--- a/meta/ja_core_web_md-2.1.0.json
+++ b/meta/ja_core_web_md-2.1.0.json
@@ -1,0 +1,43 @@
+{
+  "accuracy": {
+    "ents_f": 65.0112866817,
+    "ents_p": 65.1583710407,
+    "ents_r": 64.8648648649,
+    "las": 82.3463894561,
+    "tags_acc": 99.7989949749,
+    "token_acc": 99.5322418978,
+    "uas": 87.5069612029
+  },
+  "author": "Megagon Labs, Tokyo.",
+  "description": "Japanese multi-task CNN trained on UD_Japanese-PUD v2.4-NE. Assigns word2vec token vectors, POS tags, dependency parse and named entities with SudachiPy. Compatible with Python 3.5+",
+  "email": "ginza@megagon.ai",
+  "lang": "ja",
+  "license": "CC-BY-SA",
+  "name": "core_web_md",
+  "parent_package": "spacy",
+  "pipeline": [
+    "tagger",
+    "parser",
+    "ner",
+    "JapaneseCorrector"
+  ],
+  "sources": [
+    "jawiki-cirrussearch-content",
+    "UD_Japanese-PUD v2.4-NE"
+  ],
+  "spacy_version": ">=2.1.4",
+  "speed": {
+    "cpu": 12736.487325228,
+    "gpu": null,
+    "nwords": 2993
+  },
+  "url": "https://github.com/megagonlabs/ginza",
+  "vectors": {
+    "keys": 100000,
+    "name": "ja_pud.vectors",
+    "vectors": 117951,
+    "width": 100
+  },
+  "version": "2.1.0",
+  "size": "57 MB"
+}

--- a/meta/ja_core_web_md-2.1.0.json
+++ b/meta/ja_core_web_md-2.1.0.json
@@ -12,7 +12,7 @@
   "description": "Japanese multi-task CNN trained on UD_Japanese-PUD v2.4-NE. Assigns word2vec token vectors, POS tags, dependency parse and named entities with SudachiPy. Compatible with Python 3.5+",
   "email": "ginza@megagon.ai",
   "lang": "ja",
-  "license": "CC-BY-SA",
+  "license": "CC BY-SA 3.0",
   "name": "core_web_md",
   "parent_package": "spacy",
   "pipeline": [
@@ -25,7 +25,7 @@
     "jawiki-cirrussearch-content",
     "UD_Japanese-PUD v2.4-NE"
   ],
-  "spacy_version": ">=2.1.4",
+  "spacy_version": ">=2.1.0",
   "speed": {
     "cpu": 12736.487325228,
     "gpu": null,

--- a/shortcuts-nightly.json
+++ b/shortcuts-nightly.json
@@ -6,5 +6,6 @@
     "fr": "fr_core_news_sm",
     "it": "it_core_news_sm",
     "nl": "nl_core_news_sm",
+    "ja": "ja_core_web_md",
     "xx": "xx_ent_wiki_sm"
 }

--- a/shortcuts-v2.json
+++ b/shortcuts-v2.json
@@ -7,5 +7,6 @@
     "it": "it_core_news_sm",
     "nl": "nl_core_news_sm",
     "el": "el_core_news_sm",
+    "ja": "ja_core_web_md",
     "xx": "xx_ent_wiki_sm"
 }


### PR DESCRIPTION
I sent a pull request for Japanese language package on spaCy repository.
https://github.com/explosion/spaCy/pull/3899

And this PR is for registering ja_core_web_md.2.1.0.
The model file is here.
https://github.com/megagonlabs/UD_Japanese-PUD/releases/tag/v2.4-NE-spacy

Please give us your feedbacks.

Thanks,
Hiroshi Matsuda