### PR TITLE
Package license

### DIFF
--- a/template/LICENSE
+++ b/template/LICENSE
@@ -1,0 +1,3 @@
+Copyright (C) 2016-2019 ExplosionAI GmbH, 2016 spaCy GmbH, 2015 Matthew Honnibal
+
+License family stated in the accompanying file, meta.json.

--- a/template/MANIFEST.in
+++ b/template/MANIFEST.in
@@ -1,1 +1,2 @@
 include meta.json
+include LICENSE


### PR DESCRIPTION
Copied license file from the [spaCy repo](https://raw.githubusercontent.com/explosion/spaCy/master/LICENSE). Adding it to every model package that gets created.

I assist in maintaining the [conda-forge package](https://github.com/conda-forge/spacy-model-en_core_web-feedstock/) for `en_core_web_XX`, and would appreciate if the license file could be sourced directly from the package.