### PR TITLE
Lower NER thresholds for ja and ro

### DIFF
--- a/tests/lang/ja/test_ner.py
+++ b/tests/lang/ja/test_ner.py
@@ -10,7 +10,7 @@ TEST_FILES_DIR = Path(__file__).parent / "test_files"
 
 @pytest.mark.parametrize(
     "test_file,ents_f_threshold",
-    [("ja_gsd-ud-dev_sample.json",70)],
+    [("ja_gsd-ud-dev_sample.json",55)],
 )
 def test_ja_ner_corpus(NLP, test_file, ents_f_threshold):
     data_path = TEST_FILES_DIR / test_file

--- a/tests/lang/ro/test_ner.py
+++ b/tests/lang/ro/test_ner.py
@@ -10,7 +10,7 @@ TEST_FILES_DIR = Path(__file__).parent / "test_files"
 
 @pytest.mark.parametrize(
     "test_file,ents_f_threshold",
-    [("dev_ronec01_10.json",81)],
+    [("dev_ronec01_10.json",79)],
 )
 def test_ro_ner_corpus(NLP, test_file, ents_f_threshold):
     data_path = TEST_FILES_DIR / test_file


### PR DESCRIPTION
The NER test files are small enough that the evaluation is pretty unstable.