### PR TITLE
Fix issues with JA morph tests

### DIFF
--- a/tests/lang/ja/test_morph.py
+++ b/tests/lang/ja/test_morph.py
@@ -4,8 +4,8 @@ import pytest
 @pytest.mark.parametrize(
     "word,morph",
     [
-        ("綜合", ("ソウゴウ", "*,*")),
-        ("縁側", ("エンガワ", "*,*")),
+        ("綜合", ("ソウゴウ", "")),
+        ("縁側", ("エンガワ", "")),
         ("新しい", ("アタラシイ", "形容詞,終止形-一般")),
         ("新しくない", ("アタラシク", "形容詞,連用形-一般")),
         ("やった", ("ヤッ", "五段-ラ行,連用形-促音便")),
@@ -17,4 +17,4 @@ def test_ja_morph(NLP, word, morph):
     reading, infl = morph
 
     assert reading == doc[0].morph.get("reading")[0]
-    assert infl == doc[0].morph.get("inflection")[0]
+    assert infl.split(",") == doc[0].morph.get("inflection")


### PR DESCRIPTION
Two mistakes here on my part:

1. I forgot that blank entries (marked with `*`) are omitted
2. The inflection value is comma-separated, so it's a list in the MorphAnalysis. This should probably be changed to be hyphen delimited like the POS field. (This PR just makes the test pass by checking the whole list.)