### PR TITLE
Remove zh dep_las check

### DIFF
--- a/tests/data/performance_thresholds.csv
+++ b/tests/data/performance_thresholds.csv
@@ -89,7 +89,6 @@ sv,*,parser,sv_talbanken-ud-dev01_1.json,dep_uas,0.8
 sv,*,parser,sv_talbanken-ud-dev01_1.json,dep_las,0.75
 sv,*,tagger,sv_talbanken-ud-dev01_1.json,tag_acc,0.93
 zh,*,parser,zh_gsd-ud-dev_sample.json,dep_uas,0.25
-zh,*,parser,zh_gsd-ud-dev_sample.json,dep_las,0.05
 zh,*,segmenter,zh_gsd-ud-dev_sample.json,token_acc,0.7
 zh,*,tagger,zh_gsd-ud-dev_sample.json,tag_acc,0.32
 zh,*,tagger,zh_gsd-ud-dev_sample.json,pos_acc,0.59


### PR DESCRIPTION
The annotation format in the public test data is so different that this threshold is not useful.